### PR TITLE
Fix screenshots and authors file in publiccode.yml

### DIFF
--- a/publiccode.yml
+++ b/publiccode.yml
@@ -24,10 +24,8 @@ description:
     longDescription: |2
        The focus of the project was to improve the document archiving process in compliance with the Protocollo Informatico Italian law. In fact, the user of public administration, in order to archive a protocol, has to fill various fields, in particular: needs to write a summary of the contents of the document (_Oggetto_), pick the correct document repository for the office (_Contenitore_) and then choose the correct class among many. The model will provide a _top 3/5 prediction_ over the possible correct classes. 
     screenshots:
-      - |-
-        https://raw.githubusercontent.com/EliaPiccoli/HLT-Project/master/report/first_model.png
-      - |-
-        https://raw.githubusercontent.com/EliaPiccoli/HLT-Project/master/report/second_model.png
+      - report/first_model.png
+      - report/second_model.png
     shortDescription: |-
       The focus of the project was to improve the document archiving process in
       compliance with the Protocollo Informatico Italian law.
@@ -54,7 +52,7 @@ it:
     spid: false
 landingURL: 'https://github.com/EliaPiccoli/HLT-Project/blob/main/README.md'
 legal:
-  authorsFile: 'https://raw.githubusercontent.com/EliaPiccoli/HLT-Project/master/AUTHORS'
+  authorsFile: AUTHORS
   license: EUPL-1.2
   mainCopyrightOwner: Piccoli Elia
   repoOwner: Piccoli Elia


### PR DESCRIPTION
Screenshots and authors file are supposed to be in the same repo as
the publiccode.yml file (on the "main" branch).